### PR TITLE
Keeping default sync event behavior when tests finish

### DIFF
--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -16,9 +16,6 @@ var eventAsync = require("can-event/async/async");
 QUnit.module('can-observation',{
 	setup: function(){
 		eventAsync.sync();
-	},
-	teardown: function(){
-		eventAsync.async();
 	}
 });
 


### PR DESCRIPTION
Since sync is the default behavior of can-event, the tests for
sync should not call `async()` in teardown. This breaks other tests
when running in the canjs/canjs suite.

Closes https://github.com/canjs/can-observation/issues/22.