### PR TITLE
DONT MERGE: makes can-observation work without cid, 

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -91,10 +91,10 @@ suite.add("reading observable",
 
 		},
 		onStart: function(){
-			//console.profile("init")
+			console.profile("reading");
 		},
 		onComplete: function(){
-			//console.profileEnd("init")
+			console.profileEnd("reading");
 		},
 		onError: function(error){
 			setTimeout(function(){

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -43,8 +43,9 @@ QUnit.test('nested traps are reset onto parent traps', function() {
 		var observes1 = getObserves1();
 
 		equal(observes1.length, 2, "two items");
-		equal(observes1[0].obj, obs1);
-		equal(observes1[1].obj, obs2);
+		
+		equal(observes1[0][0], obs1);
+		equal(observes1[1][0], obs2);
 	}, null, function() {
 
 	});


### PR DESCRIPTION
uses non released version of can-util for #29