### PR TITLE
Add pushToStack() and popFromStack() methods to allow async Observations

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -1,3 +1,4 @@
+/*jshint -W003 */
 // # can-observation - nice
 //
 // This module:
@@ -90,7 +91,6 @@ var remaining = {updates: 0, notifications: 0};
  * me.name = "Ramiya"; // console.logs -> "Hello Ramiya"
  * ```
  */
-
 function Observation(func, context, compute){
 	this.newObserved = {};
 	this.oldObserved = null;
@@ -102,10 +102,13 @@ function Observation(func, context, compute){
 	this.ignore = 0;
 	this.needsUpdate= false;
 	if (!func) {
-		this.start = function(){
-			this.value = {}; // always set a unique value, so there is always an update
-		};
+		this.start = assignUniqueValue;
 	}
+}
+
+
+function assignUniqueValue() {
+ this.value = {};
 }
 
 // ### observationStack
@@ -283,7 +286,7 @@ assign(Observation.prototype,{
 	 * Starts observing all observables in general until `.popFromStack()` is called.
 	 *
 	 */
-	pushToStack() {
+	pushToStack: function() {
 		this.bound = true;
 		this.oldObserved = this.newObserved || {};
 		this.ignore = 0;
@@ -291,7 +294,7 @@ assign(Observation.prototype,{
 		// Add this function call's observation to the stack
 		observationStack.push(this);
 	},
-	popFromStack() {
+	popFromStack: function() {
 		// pops off the observation, and returns it.
 		observationStack.pop();
 		this.updateBindings();

--- a/can-observation.js
+++ b/can-observation.js
@@ -101,6 +101,11 @@ function Observation(func, context, compute){
 	this.childDepths = {};
 	this.ignore = 0;
 	this.needsUpdate= false;
+	if (!func) {
+		this.start = function(){
+			this.value = {}; // always set a unique value, so there is always an update
+		};
+	}
 }
 
 // ### observationStack
@@ -268,6 +273,28 @@ assign(Observation.prototype,{
 			this.removeEdge(ob);
 		}
 		this.newObserved = {};
+	},
+	/**
+	 * @function can-observation.prototype.pushToStack pushToStack
+	 * @parent can-observation.prototype prototype
+	 *
+	 * @signature `observation.pushToStack()`
+	 *
+	 * Starts observing all observables in general until `.popFromStack()` is called.
+	 *
+	 */
+	pushToStack() {
+		this.bound = true;
+		this.oldObserved = this.newObserved || {};
+		this.ignore = 0;
+		this.newObserved = {};
+		// Add this function call's observation to the stack
+		observationStack.push(this);
+	},
+	popFromStack() {
+		// pops off the observation, and returns it.
+		observationStack.pop();
+		this.updateBindings();
 	}
 	/**
 	 * @property {*} can-observation.prototype.value

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -402,3 +402,28 @@ QUnit.test('should throw if can-namespace.Observation is already defined', funct
 		start();
 	});
 });
+
+QUnit.test('pushToStack and popToStack allow observing reads outside of a function', function() {
+	stop(3);
+	var expected = ['Adam', 'Brian', 'Curtis', 'David'];
+	var i = 0;
+	var observable = simpleObservable('Adam');
+	var name = simpleCompute(function(){
+		return observable.get();
+	});
+	var observation = new Observation(null, null, function(newVal, oldVal, batchNum){
+		var expectedName = expected[i++];
+		QUnit.equal(name(), expectedName, 'Name has become '+expectedName+' and callback called');
+		start();
+	});
+	
+	QUnit.equal(name(), expected[i++], 'Name starts out Adam');
+	
+	observation.pushToStack();
+	name();
+	observation.popFromStack();
+	
+	observable.set('Brian');
+	observable.set('Curtis');
+	observable.set('David');
+});


### PR DESCRIPTION
Resolves #51 

When there is no `func` value passed to an Observation, the methods
pushToStack() and popFromStack() can be used to make observations outside
of the context of a function call.

I should add, as a bit of a constraint, Justin suggested I should avoid changing the code in `start()` or `update()`, because they are optimized and I wouldn't want to wreck performance that is already in place to add a new feature.