### PR TITLE
Fix the build for new version of steal-tools

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 var stealTools = require("steal-tools");
 
 stealTools.export({
-	system: {
+	steal: {
 		config: __dirname + "/package.json!npm"
 	},
 	outputs: {


### PR DESCRIPTION
The new steal-tools version requires the config object to have the property `steal` not `system`