### PR TITLE
updating namespace test to work with Steal 0.16 or Steal 1.0

### DIFF
--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -398,7 +398,8 @@ QUnit.test('should throw if can-namespace.Observation is already defined', funct
 		start();
 	})
 	.catch(function(err) {
-		ok(err && err.message.indexOf('can-observation') >= 0, 'should throw an error about can-observation');
+		var errMsg = err && err.message || err;
+		ok(errMsg.indexOf('can-observation') >= 0, 'should throw an error about can-observation');
 		start();
 	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-observation/issues/65.