### PR TITLE
Observe "reflected" interfaces

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -95,13 +95,18 @@ var canSymbol = require('can-symbol');
  * ```
  */
 
+
+
 function Observation(func, context, compute){
 	this.newObserved = {};
 	this.oldObserved = null;
 	this.func = func;
 	this.context = context;
 	this.compute = compute && compute.updater ? compute : {updater: compute};
-	this.onDependencyChange = this.onDependencyChange.bind(this);
+	var observation = this;
+	this.onDependencyChange = function(value, legacyValue){
+		observation.dependencyChange(this, value, legacyValue);
+	};
 	this.ignore = 0;
 	this.needsUpdate= false;
 	this.handlers = null;

--- a/can-observation.js
+++ b/can-observation.js
@@ -723,7 +723,7 @@ canReflect.set(Observation.prototype, canSymbol.for("can.offValue"), function(ha
 canReflect.set(Observation.prototype, canSymbol.for("can.getValue"), Observation.prototype.get);
 
 Observation.prototype.hasDependencies = function(){
-	return !isEmptyObject(this.newObserved);
+	return this.bound ? !isEmptyObject(this.newObserved) : undefined;
 };
 canReflect.set(Observation.prototype, canSymbol.for("can.isValueLike"), true);
 canReflect.set(Observation.prototype, canSymbol.for("can.isMapLike"), false);
@@ -732,26 +732,22 @@ canReflect.set(Observation.prototype, canSymbol.for("can.isListLike"), false);
 canReflect.set(Observation.prototype, canSymbol.for("can.valueHasDependencies"), Observation.prototype.hasDependencies);
 
 canReflect.set(Observation.prototype, canSymbol.for("can.getValueDependencies"), function() {
-	var rets = {},
-		bound = this.bound;
-	if(!bound) {
-		this.start();
-	}
-	canReflect.eachKey(this.newObserved || {}, function(dep) {
-		if(canReflect.isValueLike(dep.obj)) {
-			rets.valueDependencies = rets.valueDependencies || new CIDSet();
-			rets.valueDependencies.add(dep.obj);
-		} else {
-			rets.keyDependencies = rets.keyDependencies || new CIDMap();
-			if(rets.keyDependencies.get(dep.obj)) {
-				rets.keyDependencies.get(dep.obj).push(dep.event);
+	var rets;
+	if(this.bound) {
+		rets = {};
+		canReflect.eachKey(this.newObserved || {}, function(dep) {
+			if(canReflect.isValueLike(dep.obj)) {
+				rets.valueDependencies = rets.valueDependencies || new CIDSet();
+				rets.valueDependencies.add(dep.obj);
 			} else {
-				rets.keyDependencies.set(dep.obj, [dep.event]);
+				rets.keyDependencies = rets.keyDependencies || new CIDMap();
+				if(rets.keyDependencies.get(dep.obj)) {
+					rets.keyDependencies.get(dep.obj).push(dep.event);
+				} else {
+					rets.keyDependencies.set(dep.obj, [dep.event]);
+				}
 			}
-		}
-	});
-	if(!bound) {
-		this.stop();
+		});
 	}
 	return rets;
 });

--- a/can-observation.js
+++ b/can-observation.js
@@ -691,7 +691,7 @@ Observation.temporarilyBind = function (compute) {
 
 // can-reflect bindings ===========
 
-var callHandlers = function(/* newValue */){
+var callHandlers = function(newValue){
 	// todo ... we need to be able to queue a bunch at once
 	this.handlers.forEach(function(handler){
 		canBatch.queue([handler, this.compute, [newValue]]);

--- a/can-observation.js
+++ b/can-observation.js
@@ -692,7 +692,6 @@ Observation.temporarilyBind = function (compute) {
 // can-reflect bindings ===========
 
 var callHandlers = function(newValue){
-	// todo ... we need to be able to queue a bunch at once
 	this.handlers.forEach(function(handler){
 		canBatch.queue([handler, this.compute, [newValue]]);
 	}, this);

--- a/can-observation.js
+++ b/can-observation.js
@@ -712,10 +712,12 @@ canReflect.set(Observation.prototype, canSymbol.for("can.onValue"), function(han
 });
 
 canReflect.set(Observation.prototype, canSymbol.for("can.offValue"), function(handler){
-	var index = this.handlers.indexOf(handler);
-	this.handlers.splice(index, 1);
-	if(this.handlers.length === 0) {
-		this.stop();
+	if (this.handlers) {
+		var index = this.handlers.indexOf(handler);
+		this.handlers.splice(index, 1);
+		if(this.handlers.length === 0) {
+			this.stop();
+		}
 	}
 });
 

--- a/can-observation.js
+++ b/can-observation.js
@@ -150,6 +150,7 @@ assign(Observation.prototype,{
 
 		// If an external observation is tracking observables and
 		// this compute can be listened to by "function" based computes ....
+		// This doesn't happen with observations within computes
 		if( this.isObservable && Observation.isRecording() ) {
 
 
@@ -688,10 +689,10 @@ Observation.temporarilyBind = function (compute) {
 // can-reflect bindings ===========
 
 var callHandlers = function(newValue){
-	var handlers = this.handlers.slice(0);
-	for(var i = 0, len = handlers.length; i < len; i++) {
-		handlers[i].apply(this.compute, arguments);
-	}
+	// todo ... we need to be able to queue a bunch at once
+	this.handlers.forEach(function(handler){
+		canBatch.queue([handler, this.compute, [newValue]]);
+	}, this);
 };
 
 canReflect.set(Observation.prototype, canSymbol.for("can.onValue"), function(handler){

--- a/can-observation.js
+++ b/can-observation.js
@@ -183,8 +183,8 @@ assign(Observation.prototype,{
 			}
 		}
 	},
-	onDependencyChange: function(){
-		this.dependencyChange();
+	onDependencyChange: function(value){
+		this.dependencyChange(value);
 	},
 	update: function(batchNum){
 		if(this.needsUpdate) {

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -1,5 +1,5 @@
-//require("./can-observation-async-test");
-//require("./reader/reader_test");
+require("./can-observation-async-test");
+require("./reader/reader_test");
 var simple = require("./test/simple");
 var simpleObservable = simple.observable;
 var simpleCompute = simple.compute;

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -506,7 +506,9 @@ QUnit.test("Observation can itself be observable", function(){
 		return oA.get() * 3;
 	});
 
-	canReflect.onValue(oB, function(){});
+	canReflect.onValue(oB, function(){
+		QUnit.ok(canBatch.batchNum, "this was fired in a batch");
+	});
 
 
 	QUnit.equal( canReflect.getValue(oB), 9);

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -468,7 +468,7 @@ QUnit.test("should not throw if offValue is called without calling onValue" , fu
 	} catch(e) {
 		QUnit.ok(false, e);
 	}
-})
+});
 
 QUnit.test("getValueDependencies work with can-reflect", function() {
 

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -456,6 +456,20 @@ QUnit.test("onValue/offValue/getValue/isValueLike/hasValueDependencies work with
 
 });
 
+QUnit.test("should not throw if offValue is called without calling onValue" , function() {
+	var noop = function() {};
+	var observation = new Observation(function() {
+		return "Hello";
+	});
+
+	try {
+		canReflect.offValue(observation, noop);
+		QUnit.ok(true, "should not throw");
+	} catch(e) {
+		QUnit.ok(false, e);
+	}
+})
+
 QUnit.test("getValueDependencies work with can-reflect", function() {
 
 	var obs1 = assign({prop1: 1}, canEvent);

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -494,3 +494,28 @@ QUnit.test("Observation can listen to something decorated with onValue and offVa
 
 	QUnit.equal( canReflect.getValue(o), 30);
 });
+
+QUnit.test("Observation can itself be observable", function(){
+	var v1 = reflectiveObservable(1);
+	var v2 = reflectiveObservable(2);
+
+	var oA = new Observation(function(){
+		return v1.get() + v2.get();
+	});
+	var oB = new Observation(function(){
+		return oA.get() * 3;
+	});
+
+	canReflect.onValue(oB, function(){});
+
+
+	QUnit.equal( canReflect.getValue(oB), 9);
+
+	canBatch.start();
+	v1.set(10);
+	v2.set(20);
+	canBatch.stop();
+
+	QUnit.equal( canReflect.getValue(oB), 90);
+	QUnit.ok(oA.bound, "bound on oA");
+});

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -409,7 +409,7 @@ QUnit.test('should throw if can-namespace.Observation is already defined', funct
 });
 
 
-QUnit.test("onValue/offValue/getValue/isValueLike/hasValueDependencies work with can-reflect", 7,function(){
+QUnit.test("onValue/offValue/getValue/isValueLike/hasValueDependencies work with can-reflect", 8,function(){
 	var obs1 = assign({prop1: 1}, canEvent);
     CID(obs1);
     var obs2 = assign({prop2: 2}, canEvent);
@@ -425,6 +425,7 @@ QUnit.test("onValue/offValue/getValue/isValueLike/hasValueDependencies work with
 	QUnit.ok(canReflect.isValueLike(observation), "it is value like!");
 
 	QUnit.equal(canReflect.getValue(observation), 3, "get unbound");
+	QUnit.equal(canReflect.valueHasDependencies(observation), undefined, "valueHasDependencies undef'd before start");
 
 	var stop = observation.stop;
 	observation.stop = function(){
@@ -443,7 +444,7 @@ QUnit.test("onValue/offValue/getValue/isValueLike/hasValueDependencies work with
 
 	canReflect.onValue(observation, handler);
 	QUnit.equal(canReflect.getValue(observation), 3, "get bound");
-	QUnit.ok(canReflect.valueHasDependencies(observation),"valueHasDependencies");
+	QUnit.ok(canReflect.valueHasDependencies(observation),"valueHasDependencies true after start");
 	canBatch.start();
 	obs1.prop1 = 10;
 	obs2.prop2 = 20;
@@ -477,13 +478,17 @@ QUnit.test("getValueDependencies work with can-reflect", function() {
 	});
 
 	var deps = canReflect.getValueDependencies(observation);
+	QUnit.equal(deps, undefined, "getValueDependencies undefined for unstarted observation");
+
+	observation.start();
+	deps = canReflect.getValueDependencies(observation);
 	QUnit.ok(
 		deps.keyDependencies.has(obs1),
-		"valueHasDependencies"
+		"getValueDependencies -- key deps"
 	);
 	QUnit.ok(
 		deps.valueDependencies.has(obs2),
-		"valueHasDependencies"
+		"getValueDependencies -- value deps"
 	);
 
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout master && git branch -D release && git push",
+    "postversion": "git push --tags && git checkout can-reflect && git branch -D release && git push",
     "testee": "testee test.html --browsers firefox",
     "test": "npm run jshint && npm run testee",
     "jshint": "jshint *.js reader/*.js --config",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "can-event": "^3.0.1",
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-util": "^3.2.2",
+    "can-reflect": "^0.0.0",
+    "can-symbol": "^0.0.0"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "can-reflect": "^1.0.0-pre.1",
     "can-symbol": "^1.0.0-pre.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.5.0"
+    "can-util": "^3.9.0-pre.1"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.5",
+  "version": "3.2.0-pre.6",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.14",
+  "version": "3.2.0-pre.15",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "can-reflect": "^1.0.0-pre.1",
     "can-reflect-promise": "^1.0.2",
     "can-symbol": "^1.0.0-pre.0",
-    "can-types": "^1.1.0-pre.1",
     "can-util": "^3.9.0-pre.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "testee": "testee test.html --browsers firefox",
     "test": "npm run jshint && npm run testee",
     "jshint": "jshint *.js reader/*.js --config",
-    "release:pre": "npm version prerelease && npm publish",
+    "release:pre": "npm version prerelease && npm publish --tag pre",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "can-cid": "^1.0.0",
-    "can-event": "^3.0.1",
+    "can-event": "^3.1.2",
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.12",
+  "version": "3.2.0-pre.13",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.6",
+  "version": "3.2.0-pre.7",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",
-    "can-compute": "^3.0.4",
-    "can-define": "^1.0.1",
-    "can-map": "^3.0.3",
+    "can-compute": "^3.1.0-pre.11",
+    "can-define": "^1.2.0-pre.4",
+    "can-map": "^3.1.0-pre.11",
     "done-serve": "^0.2.4",
     "donejs-cli": "^0.9.5",
     "generator-donejs": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   },
   "dependencies": {
     "can-cid": "^1.0.0",
-    "can-event": "^3.3.0",
+    "can-event": "^3.5.0-pre.2",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.0.0-pre.1",
     "can-symbol": "^1.0.0-pre.0",
-    "can-types": "^1.0.1",
+    "can-types": "^1.1.0-pre.1",
     "can-util": "^3.9.0-pre.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout can-reflect && git branch -D release && git push",
+    "postversion": "git push --tags && git checkout can-reflect && git branch -D release && git push origin can-reflect",
     "testee": "testee test.html --browsers firefox",
     "test": "npm run jshint && npm run testee",
     "jshint": "jshint *.js reader/*.js --config",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.10",
+  "version": "3.2.0-pre.11",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.11",
+  "version": "3.2.0-pre.12",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2",
-    "can-reflect": "^0.0.0",
-    "can-symbol": "^0.0.0"
+    "can-reflect": "^0.X",
+    "can-symbol": "^0.X"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.1.2",
+  "version": "3.2.0-pre.0",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.17",
+  "version": "3.2.0-pre.18",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.15",
+  "version": "3.2.0-pre.16",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.18",
+  "version": "3.2.0-pre.19",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "can-cid": "^1.0.0",
     "can-event": "^3.1.2",
     "can-namespace": "1.0.0",
+    "can-reflect": "^1.0.0-pre.1",
+    "can-symbol": "^1.0.0-pre.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2",
-    "can-reflect": "^0.X",
-    "can-symbol": "^0.X"
+    "can-util": "^3.2.2"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.7",
+  "version": "3.2.0-pre.8",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.0",
+  "version": "3.2.0-pre.1",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.19",
+  "version": "3.2.0-pre.20",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.1",
+  "version": "3.2.0-pre.2",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.13",
+  "version": "3.2.0-pre.14",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.9",
+  "version": "3.2.0-pre.10",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",
-    "can-compute": "^3.1.0-pre.11",
-    "can-define": "^1.2.0-pre.4",
-    "can-map": "^3.1.0-pre.11",
+    "can-compute": "^3.1.0-pre.13",
+    "can-define": "^1.2.0-pre.6",
+    "can-map": "^3.1.0-pre.14",
     "done-serve": "^1.2.0",
     "donejs-cli": "^1.0.1",
     "generator-donejs": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,14 @@
     "can-event": "^3.5.0-pre.2",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.0.0-pre.1",
+    "can-reflect-promise": "^1.0.2",
     "can-symbol": "^1.0.0-pre.0",
     "can-types": "^1.1.0-pre.1",
-    "can-util": "^3.9.0-pre.1"
+    "can-util": "^3.9.0-pre.4"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",
-    "can-compute": "^3.1.0-pre.13",
+    "can-compute": "^3.1.0-pre.14",
     "can-define": "^1.2.0-pre.6",
     "can-map": "^3.1.0-pre.14",
     "done-serve": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.4",
+  "version": "3.2.0-pre.5",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.3",
+  "version": "3.2.0-pre.4",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.8",
+  "version": "3.2.0-pre.9",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.16",
+  "version": "3.2.0-pre.17",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-observation",
-  "version": "3.2.0-pre.2",
+  "version": "3.2.0-pre.3",
   "description": "Core observable indicators",
   "homepage": "http://canjs.com",
   "author": {

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -183,24 +183,18 @@ observeReader = {
 	propertyReaders: [
 		{
 			name: "map",
-			test: function(){
-				return types.isMapLike.apply(this, arguments) || types.isListLike.apply(this, arguments);
+			test: function(value){
+				return canReflect.isObservableLike(value) && canReflect.isMapLike(value);
 			},
 			read: function(value, prop, index, options, state){
-				var res = value.get ? value.get(prop.key) : value.attr(prop.key);
+				var res = canReflect.getKeyValue(value, prop.key);
 				if(res !== undefined) {
 					return res;
 				} else {
 					return value[prop.key];
 				}
 			},
-			write: function(base, prop, newVal){
-				if(typeof base.set === "function") {
-					base.set(prop, newVal);
-				} else {
-					base.attr(prop, newVal);
-				}
-			}
+			write: canReflect.setKeyValue
 		},
 		// read a promise
 		// it would be good to remove this ... then

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -8,6 +8,7 @@ var each = require('can-util/js/each/each');
 var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 var isPromiseLike = require('can-util/js/is-promise-like/is-promise-like');
+var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 
 
 var getValueSymbol = canSymbol.for("can.getValue");
@@ -144,7 +145,7 @@ observeReader = {
 			name: "function",
 			// if this is a function before the last read and its not a constructor function
 			test: function(value, i, reads, options){
-				return types.isCallableForValue(value) && !types.isCompute(value);
+				return (types.isCallableForValue(value) || typeof value === "function" && isEmptyObject(value.prototype)) && !types.isCompute(value);
 			},
 			read: function(value, i, reads, options, state, prev){
 				if( isAt(i, reads) ) {

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -334,6 +334,9 @@ observeReader = {
 			}
 			else if(observeReader.propertyReadersMap.object.test(parent)) {
 				observeReader.propertyReadersMap.object.write(parent, last.key, value, options);
+				if(options.observation) {
+					options.observation.update();
+				}
 			}
 		}
 	}

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -1,5 +1,4 @@
 var Observation = require('can-observation');
-var types = require('can-types');
 var dev = require('can-util/js/dev/dev');
 var each = require('can-util/js/each/each');
 var canSymbol = require("can-symbol");
@@ -147,7 +146,7 @@ observeReader = {
 				if( isAt(i, reads) ) {
 					return i === reads.length ? value.bind(prev) : value;
 				}
-				else if(options.callMethodsOnObservables && types.isMapLike(prev)) {
+				else if(options.callMethodsOnObservables && canReflect.isObservableLike(prev) && canReflect.isMapLike(prev)) {
 					return value.apply(prev, options.args || []);
 				}
 				else if ( options.isArgument && i === reads.length ) {

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -6,7 +6,6 @@ var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 var isPromiseLike = require('can-util/js/is-promise-like/is-promise-like');
 var canReflectPromise = require("can-reflect-promise");
-var isEmptyObject = require("can-util/js/is-empty-object/is-empty-object");
 
 var getValueSymbol = canSymbol.for("can.getValue");
 var isValueLikeSymbol = canSymbol.for("can.isValueLike");
@@ -142,7 +141,7 @@ observeReader = {
 			name: "function",
 			// if this is a function before the last read and its not a constructor function
 			test: function(value, i, reads, options){
-				return (types.isCallableForValue(value) || typeof value === "function" && isEmptyObject(value.prototype)) && !types.isCompute(value);
+				return value && canReflect.isFunctionLike(value) && !canReflect.isConstructorLike(value);
 			},
 			read: function(value, i, reads, options, state, prev){
 				if( isAt(i, reads) ) {

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -5,7 +5,11 @@ var types = require('can-types');
 var dev = require('can-util/js/dev/dev');
 var canEvent = require('can-event');
 var each = require("can-util/js/each/each");
+var canSymbol = require("can-symbol");
+var canReflect = require("can-reflect");
 
+
+var getValueSymbol = canSymbol.for("can.getValue");
 var observeReader;
 var isAt = function(index, reads) {
 	var prevRead = reads[index-1];
@@ -154,16 +158,16 @@ observeReader = {
 			}
 		},
 		{
-			name: "compute",
+			name: "isValueLike",
 			// compute value reader
 			test: function(value, i, reads, options){
-				return types.isCompute(value) && !isAt(i, reads);
+				return value && value[getValueSymbol] && !isAt(i, reads);
 			},
 			read: function(value, i, reads, options, state){
 				if(options.readCompute === false && i === reads.length ) {
 					return value;
 				}
-				return value.get ? value.get() : value();
+				return canReflect.getValue(value);
 			},
 			write: function(base, newVal){
 				if(base.set) {
@@ -317,10 +321,10 @@ observeReader = {
 		// here's where we need to figure out the best way to write
 
 		// if property being set points at a compute, set the compute
-		if( observeReader.valueReadersMap.compute.test(parent[last.key], keys.length - 1, keys, options) ) {
-			observeReader.valueReadersMap.compute.write(parent[last.key], value, options);
+		if( observeReader.valueReadersMap.isValueLike.test(parent[last.key], keys.length - 1, keys, options) ) {
+			observeReader.valueReadersMap.isValueLike.write(parent[last.key], value, options);
 		} else {
-			if(observeReader.valueReadersMap.compute.test(parent, keys.length - 1, keys, options) ) {
+			if(observeReader.valueReadersMap.isValueLike.test(parent, keys.length - 1, keys, options) ) {
 				parent = parent();
 			}
 			if(observeReader.propertyReadersMap.map.test(parent)) {

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -307,6 +307,9 @@ observeReader = {
 	write: function(parent, key, value, options) {
 		var keys = typeof key === "string" ? observeReader.reads(key) : key;
 		var last;
+
+		options = options || {};
+
 		if(keys.length > 1) {
 			last = keys.pop();
 			parent = observeReader.read(parent, keys, options).value;

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -161,7 +161,7 @@ observeReader = {
 			name: "isValueLike",
 			// compute value reader
 			test: function(value, i, reads, options){
-				return value && value[getValueSymbol] && !isAt(i, reads);
+				return value && value[getValueSymbol] && (options.foundAt || !isAt(i, reads) );
 			},
 			read: function(value, i, reads, options, state){
 				if(options.readCompute === false && i === reads.length ) {
@@ -247,7 +247,7 @@ observeReader = {
 			name: "object",
 			// this is the default
 			test: function(){return true;},
-			read: function(value, prop){
+			read: function(value, prop, i, options){
 				if(value == null) {
 					return undefined;
 				} else {
@@ -257,6 +257,7 @@ observeReader = {
 						}
 						// TODO: remove in 3.0.  This is for backwards compat with @key and @index.
 						else if( prop.at && specialRead[prop.key] && ( ("@"+prop.key) in value)) {
+							options.foundAt = true;
 							//!steal-remove-start
 							dev.warn("Use %"+prop.key+" in place of @"+prop.key+".");
 

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -10,6 +10,7 @@ var canReflect = require("can-reflect");
 
 
 var getValueSymbol = canSymbol.for("can.getValue");
+var isValueLikeSymbol = canSymbol.for("can.isValueLike");
 var observeReader;
 var isAt = function(index, reads) {
 	var prevRead = reads[index-1];
@@ -161,7 +162,7 @@ observeReader = {
 			name: "isValueLike",
 			// compute value reader
 			test: function(value, i, reads, options){
-				return value && value[getValueSymbol] && (options.foundAt || !isAt(i, reads) );
+				return value && value[getValueSymbol] && value[isValueLikeSymbol] !== false && (options.foundAt || !isAt(i, reads) );
 			},
 			read: function(value, i, reads, options, state){
 				if(options.readCompute === false && i === reads.length ) {

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -9,6 +9,7 @@ var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
 var compute = require("can-compute");
 var eventAsync = require("can-event/async/async");
+var canSymbol = require("can-symbol");
 
 QUnit.module('can-observation/reader',{
 	setup: function(){
@@ -131,6 +132,7 @@ test("foundObservable called with observable object (#7)", function(){
 		},
 		addEventListener: function(){}
 	};
+
 	// must use an observation to make sure things are listening.
 	var c = new Observation(function(){
 		observeReader.read(map,observeReader.reads("isSaving"),{

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -9,7 +9,6 @@ var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
 var compute = require("can-compute");
 var eventAsync = require("can-event/async/async");
-var canSymbol = require("can-symbol");
 
 QUnit.module('can-observation/reader',{
 	setup: function(){

--- a/test/simple.js
+++ b/test/simple.js
@@ -74,10 +74,10 @@ var reflectiveCompute = function(getter, name){
 
 	observation = new Observation(getter);
 
-	canReflect.set(fn, Symbol.for("can.onValue"), function(handler){
+	canReflect.set(fn, canSymbol.for("can.onValue"), function(handler){
 		canReflect.onValue( observation, handler );
 	});
-	canReflect.set(fn, Symbol.for("can.offValue"), function(handler){
+	canReflect.set(fn, canSymbol.for("can.offValue"), function(handler){
 		canReflect.offValue( observation, handler );
 	});
 	//canReflect.set(fn, Symbol.for("can.getValue"), observation.get.bind(observation));
@@ -99,10 +99,10 @@ var reflectiveValue = function(value){
 		}
 	};
 	CID(fn);
-	canReflect.set(fn, Symbol.for("can.onValue"), function(handler){
+	canReflect.set(fn, canSymbol.for("can.onValue"), function(handler){
 		handlers.push(handler);
 	});
-	canReflect.set(fn, Symbol.for("can.offValue"), function(handler){
+	canReflect.set(fn, canSymbol.for("can.offValue"), function(handler){
 		var index = handlers.indexOf(handler);
 		handlers.splice(index, 1);
 	});
@@ -124,10 +124,10 @@ var reflectiveObservable = function(value){
 		value: value,
 		handlers: {value: []}
 	};
-	canReflect.set(obs, Symbol.for("can.onKeyValue"), function(eventName, handler){
+	canReflect.set(obs, canSymbol.for("can.onKeyValue"), function(eventName, handler){
 		this.handlers[eventName].push(handler);
 	});
-	canReflect.set(obs, Symbol.for("can.offKeyValue"), function(eventName, handler){
+	canReflect.set(obs, canSymbol.for("can.offKeyValue"), function(eventName, handler){
 		var index = this.handlers.value.indexOf(handler);
 		this.handlers[eventName].splice(index, 1);
 	});

--- a/test/simple.js
+++ b/test/simple.js
@@ -3,7 +3,11 @@ var CID = require('can-cid');
 
 var assign = require("can-util/js/assign/assign");
 var canEvent = require('can-event');
+var canBatch = require('can-event/batch/batch');
 var eventLifecycle = require("can-event/lifecycle/lifecycle");
+
+var canReflect = require("can-reflect");
+var canSymbol = require("can-symbol");
 
 // a simple observable and compute to test
 // behaviors that require nesting of Observations
@@ -57,7 +61,85 @@ var simpleCompute = function(getter, name, primaryDepth){
 	return fn;
 };
 
+var reflectiveCompute = function(getter, name){
+	var observation,
+		fn,
+		handlers = [];
+
+	fn = function(){
+		Observation.add(fn);
+		return observation.get();
+	};
+	CID(fn, name);
+
+	observation = new Observation(getter);
+
+	canReflect.set(fn, Symbol.for("can.onValue"), function(handler){
+		canReflect.onValue( observation, handler );
+	});
+	canReflect.set(fn, Symbol.for("can.offValue"), function(handler){
+		canReflect.offValue( observation, handler );
+	});
+	//canReflect.set(fn, Symbol.for("can.getValue"), observation.get.bind(observation));
+
+	return fn;
+};
+var reflectiveValue = function(value){
+	var handlers = [];
+
+	var fn = function(newValue){
+		if(arguments.length) {
+			value = newValue;
+			handlers.forEach(function(handler){
+				canBatch.queue([handler, fn, [newValue]]);
+			}, this);
+		} else {
+			Observation.add(fn);
+			return value;
+		}
+	};
+	CID(fn);
+	canReflect.set(fn, Symbol.for("can.onValue"), function(handler){
+		handlers.push(handler);
+	});
+	canReflect.set(fn, Symbol.for("can.offValue"), function(handler){
+		var index = handlers.indexOf(handler);
+		handlers.splice(index, 1);
+	});
+	return fn;
+};
+
+var reflectiveObservable = function(value){
+	var obs = {
+		get: function(){
+			Observation.add(this, "value");
+			return this.value;
+		},
+		set: function(value){
+			this.value = value;
+			this.handlers.value.forEach(function(handler){
+				canBatch.queue([handler, this, [value]]);
+			}, this);
+		},
+		value: value,
+		handlers: {value: []}
+	};
+	canReflect.set(obs, Symbol.for("can.onKeyValue"), function(eventName, handler){
+		this.handlers[eventName].push(handler);
+	});
+	canReflect.set(obs, Symbol.for("can.offKeyValue"), function(eventName, handler){
+		var index = this.handlers.value.indexOf(handler);
+		this.handlers[eventName].splice(index, 1);
+	});
+
+	CID(obs);
+	return obs;
+};
+
 module.exports = {
 	compute: simpleCompute,
-	observable: simpleObservable
+	observable: simpleObservable,
+	reflectiveCompute: reflectiveCompute,
+	reflectiveValue: reflectiveValue,
+	reflectiveObservable: reflectiveObservable
 };


### PR DESCRIPTION
This will allow can-observation to observe any `can-reflect`-ed interface (instead of just those supporting `addEventListener` and `removeEventListener`.

Eventually, this should let us Observation and thin wrappers around Observation most places within CanJS to improve performance.

This includes a little test code that shows an Observation initializes 3x faster than a can-compute.

This also lets one bind to an observation through the `can-reflect.onValue` and `can-reflect.offValue` APIs