### PR TITLE
#70 report promise errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "can-event": "^3.0.1",
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-util": "^3.5.0"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -231,8 +231,13 @@ observeReader = {
 						observeData.reason = reason;
 						observeData.state = "rejected";
 						observeData.dispatch("state",["rejected","pending"]);
+
+						setTimeout(function() {
+							throw new Error(reason);
+						}, 1);
 					});
 				}
+
 				Observation.add(observeData,"state");
 				return prop.key in observeData ? observeData[prop.key] : value[prop.key];
 			}

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -232,9 +232,7 @@ observeReader = {
 						observeData.state = "rejected";
 						observeData.dispatch("state",["rejected","pending"]);
 
-						setTimeout(function() {
-							throw new Error(reason);
-						}, 1);
+						throw reason instanceof Error ? reason : new Error(reason);
 					});
 				}
 

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -232,7 +232,9 @@ observeReader = {
 						observeData.state = "rejected";
 						observeData.dispatch("state",["rejected","pending"]);
 
-						throw reason instanceof Error ? reason : new Error(reason);
+						//!steal-remove-start
+						dev.error("Failed promise:", reason);
+						//!steal-remove-end
 					});
 				}
 

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -2,6 +2,7 @@ var observeReader = require("./reader");
 var QUnit = require('steal-qunit');
 var Observation = require('can-observation');
 var canEvent = require('can-event');
+var dev = require('can-util/js/dev/dev');
 
 var assign = require("can-util/js/assign/assign");
 var DefineMap = require("can-define/map/map");
@@ -178,29 +179,25 @@ test("write to a map in a compute", function(){
 	QUnit.equal(map.complete, false, "value set");
 });
 
-// TODO: How can we test this? Neither onerror or onunhandledrejection catches
-// test("promise readers throw errors (#70)", function() {
-// 	expect(1);
-// 	window.onerror = function(message) {
-// 		if (message === "Uncaught Error: Something") {
-// 			ok(true);
-// 			start();
-// 			return true;
-// 		}
-//
-// 		return false;
-// 	};
-//
-// 	var promise = new Promise(function(resolve, reject) {
-// 		setTimeout(function() {
-// 			reject("Something");
-// 		}, 0);
-// 	});
-//
-// 	var c = new Observation(function() {
-// 		return observeReader.read(promise, observeReader.reads("value"), {}).value;
-// 	}, null, { updater: function() {} });
-//
-// 	c.start();
-// 	stop();
-// });
+test("promise readers throw errors (#70)", function() {
+	expect(1);
+	var oldError = dev.error;
+	dev.error = function() {
+		dev.error = oldError;
+		ok(true);
+		start();
+	};
+
+	var promise = new Promise(function(resolve, reject) {
+		setTimeout(function() {
+			reject("Something");
+		}, 0);
+	});
+
+	var c = new Observation(function() {
+		return observeReader.read(promise, observeReader.reads("value"), {}).value;
+	}, null, { updater: function() {} });
+
+	c.start();
+	stop();
+});

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -178,28 +178,29 @@ test("write to a map in a compute", function(){
 	QUnit.equal(map.complete, false, "value set");
 });
 
-test("promise readers throw errors (#70)", function() {
-	expect(1);
-	window.onerror = function(message) {
-		if (message === "Uncaught Error: Something") {
-			ok(true);
-			start();
-			return true;
-		}
-
-		return false;
-	};
-
-	var promise = new Promise(function(resolve, reject) {
-		setTimeout(function() {
-			reject("Something");
-		}, 0);
-	});
-
-	var c = new Observation(function() {
-		return observeReader.read(promise, observeReader.reads("value"), {}).value;
-	}, null, { updater: function() {} });
-
-	c.start();
-	stop();
-});
+// TODO: How can we test this? Neither onerror or onunhandledrejection catches
+// test("promise readers throw errors (#70)", function() {
+// 	expect(1);
+// 	window.onerror = function(message) {
+// 		if (message === "Uncaught Error: Something") {
+// 			ok(true);
+// 			start();
+// 			return true;
+// 		}
+//
+// 		return false;
+// 	};
+//
+// 	var promise = new Promise(function(resolve, reject) {
+// 		setTimeout(function() {
+// 			reject("Something");
+// 		}, 0);
+// 	});
+//
+// 	var c = new Observation(function() {
+// 		return observeReader.read(promise, observeReader.reads("value"), {}).value;
+// 	}, null, { updater: function() {} });
+//
+// 	c.start();
+// 	stop();
+// });

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -179,24 +179,22 @@ test("write to a map in a compute", function(){
 });
 
 test("promise readers throw errors (#70)", function() {
+	expect(1);
+	window.onerror = function(message) {
+		if (message === "Uncaught Error: Something") {
+			ok(true);
+			start();
+			return true;
+		}
+
+		return false;
+	};
+
 	var promise = new Promise(function(resolve, reject) {
 		setTimeout(function() {
 			reject("Something");
 		}, 0);
 	});
-
-	var _setTimeout = setTimeout;
-	setTimeout = function(fn, delay) {
-		let matches = fn.toString().includes("throw new Error(reason)");
-		ok(matches);
-
-		if (matches) {
-			setTimeout = _setTimeout;
-			return start();
-		} else {
-			return _setTimeout(fn, delay);
-		}
-	};
 
 	var c = new Observation(function() {
 		return observeReader.read(promise, observeReader.reads("value"), {}).value;


### PR DESCRIPTION
Catches and display rejected promises.

As seen in the commits, the first test overwrote setTimeout, which seemed very hacky. Now, it uses window.onerror. I tried using window.addEventListener (since you can't remove an onerror), but the tester was still seeing the error (despite calling `event.preventDefault()` and `event.stopPropagation()`).