### PR TITLE
Allowing you two write a property containing a `.` to a CanMap

### DIFF
--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -20,8 +20,6 @@ QUnit.module('can-observation',{
 	}
 });
 
-
-
 QUnit.test('nested traps are reset onto parent traps', function() {
     var obs1 = assign({}, canEvent);
     CID(obs1);

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -1,5 +1,5 @@
-//require("./can-observation-async-test");
-//require("./reader/reader_test");
+require("./can-observation-async-test");
+require("./reader/reader_test");
 var simple = require("./test/simple");
 var simpleObservable = simple.observable;
 var simpleCompute = simple.compute;

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -193,7 +193,11 @@ observeReader = {
 				if(typeof base.set === "function") {
 					base.set(prop, newVal);
 				} else {
-					base.attr(prop, newVal);
+					if (prop.indexOf('.') === -1) {
+						base.attr(prop, newVal);
+					} else {
+						base.attr({ [prop]: newVal });
+					}
 				}
 			}
 		},

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -4,6 +4,7 @@ var Observation = require('can-observation');
 var canEvent = require('can-event');
 
 var assign = require("can-util/js/assign/assign");
+var CanMap = require("can-map");
 var DefineMap = require("can-define/map/map");
 var DefineList = require("can-define/list/list");
 var compute = require("can-compute");
@@ -17,8 +18,6 @@ QUnit.module('can-observation/reader',{
 		eventAsync.async();
 	}
 });
-
-
 
 test("can.Compute.read can read a promise (#179)", function(){
 	var data = {
@@ -121,6 +120,29 @@ test("can read from strings", function(){
 
 	var result =  observeReader.read(context,observeReader.reads("trim"),{});
 	QUnit.ok(result, context.trim);
+});
+
+test("read / write to CanMap", function(){
+	var map = new CanMap();
+	var c = new Observation(function(){
+		var data = observeReader.read(map,observeReader.reads("value"),{
+			foundObservable: function(obs){
+				QUnit.equal(obs, map, "got map");
+			}
+		});
+		return data.value;
+	}, null,function(newVal){
+		QUnit.equal(newVal, 1, "got updated");
+	});
+	c.start();
+	observeReader.write(map, "value", 1);
+});
+
+test("write properties with dots in their name in CanMap", function(){
+	var map = new CanMap();
+	observeReader.write(map, "foo\\.bar", 1);
+
+	QUnit.equal(map.attr('foo\.bar'), 1, "value set");
 });
 
 test("read / write to DefineMap", function(){


### PR DESCRIPTION
closes https://github.com/canjs/can-observation/issues/75.