### PR TITLE
#70 report promise errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "can-event": "^3.3.0",
     "can-namespace": "1.0.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-util": "^3.5.0"
   },
   "devDependencies": {
     "bit-docs": "^0.0.7",

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -231,8 +231,13 @@ observeReader = {
 						observeData.reason = reason;
 						observeData.state = "rejected";
 						observeData.dispatch("state",["rejected","pending"]);
+
+						//!steal-remove-start
+						dev.error("Failed promise:", reason);
+						//!steal-remove-end
 					});
 				}
+
 				Observation.add(observeData,"state");
 				return prop.key in observeData ? observeData[prop.key] : value[prop.key];
 			}

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -2,6 +2,7 @@ var observeReader = require("./reader");
 var QUnit = require('steal-qunit');
 var Observation = require('can-observation');
 var canEvent = require('can-event');
+var dev = require('can-util/js/dev/dev');
 
 var assign = require("can-util/js/assign/assign");
 var DefineMap = require("can-define/map/map");
@@ -176,4 +177,27 @@ test("write to a map in a compute", function(){
 	observeReader.write(computeObject, "complete", false);
 
 	QUnit.equal(map.complete, false, "value set");
+});
+
+test("promise readers throw errors (#70)", function() {
+	expect(1);
+	var oldError = dev.error;
+	dev.error = function() {
+		dev.error = oldError;
+		ok(true);
+		start();
+	};
+
+	var promise = new Promise(function(resolve, reject) {
+		setTimeout(function() {
+			reject("Something");
+		}, 0);
+	});
+
+	var c = new Observation(function() {
+		return observeReader.read(promise, observeReader.reads("value"), {}).value;
+	}, null, { updater: function() {} });
+
+	c.start();
+	stop();
 });


### PR DESCRIPTION
Catches and display rejected promises.

Duplicate of #73, as that one was accidentally merged.