### PR TITLE
allowing can-observation to read promise-like values

### DIFF
--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -1,5 +1,5 @@
-//require("./can-observation-async-test");
-//require("./reader/reader_test");
+require("./can-observation-async-test");
+require("./reader/reader_test");
 var simple = require("./test/simple");
 var simpleObservable = simple.observable;
 var simpleCompute = simple.compute;

--- a/reader/reader.js
+++ b/reader/reader.js
@@ -4,7 +4,8 @@ var CID = require('can-cid');
 var types = require('can-types');
 var dev = require('can-util/js/dev/dev');
 var canEvent = require('can-event');
-var each = require("can-util/js/each/each");
+var each = require('can-util/js/each/each');
+var isPromiseLike = require('can-util/js/is-promise-like/is-promise-like');
 
 var observeReader;
 var isAt = function(index, reads) {
@@ -203,7 +204,8 @@ observeReader = {
 		{
 			name: "promise",
 			test: function(value){
-				return types.isPromise(value);
+				// eventually this will use canReflect.isPromiseLike
+				return isPromiseLike(value);
 			},
 			read: function(value, prop, index, options, state){
 				var observeData = value.__observeData;

--- a/reader/reader_test.js
+++ b/reader/reader_test.js
@@ -18,8 +18,6 @@ QUnit.module('can-observation/reader',{
 	}
 });
 
-
-
 test("can.Compute.read can read a promise (#179)", function(){
 	var data = {
 		promise: new Promise(function(resolve){
@@ -31,6 +29,34 @@ test("can.Compute.read can read a promise (#179)", function(){
 	var calls = 0;
 	var c = new Observation(function(){
 		return observeReader.read(data,observeReader.reads("promise.value")).value;
+	}, null, {
+		updater: function(newVal, oldVal){
+			calls++;
+			equal(calls, 1, "only one call");
+			equal(newVal, "Something", "new value");
+			equal(oldVal, undefined, "oldVal");
+			start();
+		}
+	});
+	c.start();
+
+	stop();
+
+});
+
+test("can.Compute.read can read a promise-like (#82)", function(){
+	var data = {
+		promiseLike: {
+			then: function(resolve) {
+				setTimeout(function(){
+					resolve("Something");
+				}, 2);
+			}
+		}
+	};
+	var calls = 0;
+	var c = new Observation(function(){
+		return observeReader.read(data,observeReader.reads("promiseLike.value")).value;
 	}, null, {
 		updater: function(newVal, oldVal){
 			calls++;


### PR DESCRIPTION
closes https://github.com/canjs/can-observation/issues/82.