### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "can-cid": "^1.0.0",
-    "can-event": "^3.5.0-pre.2",
+    "can-event": "^3.6.0",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.0.0-pre.1",
     "can-symbol": "^1.0.0-pre.0",


### PR DESCRIPTION
Closes #92 