### PR TITLE
chore(package): update can-define to version 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "bit-docs": "^0.0.7",
     "can-compute": "^3.1.0-pre.14",
-    "can-define": "^1.2.0-pre.6",
+    "can-define": "^1.3.2",
     "can-map": "^3.1.0-pre.14",
     "done-serve": "^1.2.0",
     "donejs-cli": "^1.0.1",


### PR DESCRIPTION
Closes #91 