### PR TITLE
Replaced console with canLog from can-util

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -699,7 +699,7 @@ canReflect.set(Observation.prototype, canSymbol.for("can.onValue"), function(han
 		this.handlers = [];
 		//!steal-remove-start
 		if(this.compute.updater) {
-			console.warn("can-observation bound to with an existing handler");
+			canLog.warn("can-observation bound to with an existing handler");
 		}
 		//!steal-remove-end
 		this.compute.updater = callHandlers.bind(this);


### PR DESCRIPTION
In IE9 window.console is not available unless the dev tools are open and will silently break execution anytime it is referenced.

Replaces `console` with our `canLog` function from `can-util`

For canjs/canjs#3482