### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -313,6 +313,7 @@ assign(Observation.prototype,{
 	}
 	/**
 	 * @property {*} can-observation.prototype.value
+	 * @hide
 	 *
 	 * The return value of the function once [can-observation.prototype.start] is called.
 	 *


### PR DESCRIPTION
I’m not sure if these docs should be hidden or if the correct @parent should be added.

Part of https://github.com/canjs/canjs/issues/3660