### PR TITLE
Add a value property getter

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -73,7 +73,7 @@ canReflect.assign(Observation.prototype, {
 		// Start recording dependencies.
 		ObservationRecorder.start();
 		// Call the observation's function and update the new value.
-		this.value = this.func.call(this.context);
+		this._value = this.func.call(this.context);
 		// Get the new dependencies.
 		this.newDependencies = ObservationRecorder.stop();
 
@@ -121,13 +121,13 @@ canReflect.assign(Observation.prototype, {
 	update: function() {
 		if (this.bound === true) {
 			// Keep the old value.
-			var oldValue = this.value;
+			var oldValue = this._value;
 			this.oldValue = null;
 			// Re-run `this.func` and update dependency bindings.
 			this.onBound();
 			// If our value changed, call the `dispatch` method provided by `can-event-queue/value/value`.
-			if (oldValue !== this.value) {
-				this[dispatchSymbol](this.value, oldValue);
+			if (oldValue !== this._value) {
+				this[dispatchSymbol](this._value, oldValue);
 			}
 		}
 	},
@@ -165,7 +165,7 @@ canReflect.assign(Observation.prototype, {
 				Observation.updateChildrenAndSelf(this);
 			}
 
-			return this.value;
+			return this._value;
 		} else {
 			// If we are not bound, just call the function.
 			return this.func.call(this.context);
@@ -201,6 +201,12 @@ canReflect.assign(Observation.prototype, {
 			};
 		}
 		//!steal-remove-end
+	}
+});
+
+Object.defineProperty(Observation.prototype, "value", {
+	get: function() {
+		return this.get();
 	}
 });
 

--- a/can-observation.js
+++ b/can-observation.js
@@ -24,6 +24,9 @@ function Observation(func, context, options){
 	// A flag if we are bound or not
 	this.bound = false;
 
+	// Set _value to undefined so can-view-scope & can-compute can check for it
+	this._value = undefined;
+
 	// These properties will manage what our new and old dependencies are.
 	this.newDependencies = ObservationRecorder.makeDependenciesRecord();
 	this.oldDependencies = null;

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -409,7 +409,7 @@ QUnit.test("getValueDependencies work with can-reflect", function() {
 
 });
 
-QUnit.test("Observation can listen to something decorated with onValue and offValue", function(){
+QUnit.test("Observation can listen to value decorated with onValue and offValue", function(){
 	var v1 = reflectiveValue(1);
 	var v2 = reflectiveValue(2);
 
@@ -430,7 +430,7 @@ QUnit.test("Observation can listen to something decorated with onValue and offVa
 });
 
 
-QUnit.test("Observation can listen to something decorated with onValue and offValue", function(){
+QUnit.test("Observation can listen to observable decorated with onValue and offValue", function(){
 	var v1 = reflectiveObservable(1);
 	var v2 = reflectiveObservable(2);
 

--- a/can-observation_test.js
+++ b/can-observation_test.js
@@ -584,3 +584,13 @@ skipProductionTest("Observation decorates onDependencyChange handler", function(
 		"onDependencyChange changes the observation"
 	);
 });
+
+QUnit.test("value property getter", function() {
+	var observation = new Observation(function() {
+		return "Hello";
+	});
+
+	// Check getting the value
+	QUnit.equal(observation.value, "Hello", "value returns");
+
+});

--- a/doc/can-observation.md
+++ b/doc/can-observation.md
@@ -2,7 +2,6 @@
 @parent can-observables
 @collection can-infrastructure
 @group can-observation.prototype prototype
-@group can-observation.types types
 @package ../package.json
 
 Create observable values that derive their value from other observable
@@ -90,4 +89,4 @@ Use [can-observation.prototype.off] to unbind.
     observables call OR.add.
   - Binds to those using recorder-dependency-helpers
     - when a change happens, adds itself to the notify queue
-      - repeats process 
+      - repeats process

--- a/doc/can-observation.md
+++ b/doc/can-observation.md
@@ -25,7 +25,7 @@ const fullName = new Observation( function() {
 	return person.first + " " + person.last;
 } );
 
-fullName.get(); //-> "Ramiya Meyer";
+fullName.value; //-> "Ramiya Meyer";
 
 fullName.on( function( newName ) {
 	newName; //-> "Bodhi Meyer"
@@ -71,7 +71,7 @@ const fullName = new Observation( function() {
 	return person.first + " " + person.last;
 } );
 
-fullName.get(); //-> "Ramiya Meyer";
+fullName.value; //-> "Ramiya Meyer";
 
 fullName.on( function( newName ) {
 	newName; //-> "Bodhi Meyer"

--- a/doc/value.md
+++ b/doc/value.md
@@ -1,0 +1,21 @@
+@property can-observation.prototype.value value
+@parent can-observation.prototype
+@description Reads the value of the observation.
+@signature `observation.value`
+
+The following creates a `fullName` observation that derives its values from
+the `person` observable. The value of the observation is read with
+`fullName.value`:
+
+```js
+import Observation from "can-observation";
+import observe from "can-observe";
+
+const person = observe( { first: "Grace", last: "Hopper" } );
+
+const fullName = new Observation( function() {
+	return person.first + " " + person.last;
+} );
+
+fullName.value; //-> "Grace Hopper";
+```


### PR DESCRIPTION
This adds an API for getting the value of an observation by replacing the old internal `value` property with `_value` and adding a new `value` getter so the following works:

```js
import Observation from "can-observation";

const observation = new Observation(() => 15);
observation.value; // is 15
```

Closes https://github.com/canjs/can-observation/issues/130