### PR TITLE
Making it possible to order observation updates by their depth automatically

### DIFF
--- a/can-observation.js
+++ b/can-observation.js
@@ -246,7 +246,7 @@ var observationProto = {
 	},
 	"can.setElement": function(element) {
 		this.options.element = element;
-		this.deriveQueue = queues.domDeriveQueue || queues.deriveQueue;
+		this.deriveQueue = queues.domQueue || queues.deriveQueue;
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "can-log": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-observation-recorder": "^1.0.0",
-    "can-queues": "canjs/can-queues#dom-queue",
+    "can-queues": "^1.3.0",
     "can-reflect": "^1.7.0",
     "can-symbol": "^1.4.2"
   },


### PR DESCRIPTION
closes https://github.com/canjs/can-observation/issues/125 for elements with a `can.setElement` symbol.